### PR TITLE
Add missing image variable to CollectableTypeComponent

### DIFF
--- a/backend/src/main/java/tech/geocodeapp/geocode/collectable/decorator/CollectableTypeComponent.java
+++ b/backend/src/main/java/tech/geocodeapp/geocode/collectable/decorator/CollectableTypeComponent.java
@@ -23,6 +23,10 @@ public interface CollectableTypeComponent {
 
     void setId(UUID id);
 
+    String getImage();
+
+    void setImage(String image);
+
     CollectableSet getCollectableSet();
 
     void setCollectableSet(CollectableSet set);

--- a/backend/src/main/java/tech/geocodeapp/geocode/collectable/decorator/CollectableTypeDecorator.java
+++ b/backend/src/main/java/tech/geocodeapp/geocode/collectable/decorator/CollectableTypeDecorator.java
@@ -63,6 +63,21 @@ public abstract class CollectableTypeDecorator implements CollectableTypeCompone
     }
 
     /**
+     * @return the image of the decoratedType
+     */
+    public String getImage(){
+        return decoratedType.getImage();
+    }
+
+    /**
+     * Sets the decoratedType's image
+     * @param image the location string of the CollectableType's image
+     */
+    public void setImage(String image){
+        decoratedType.setImage(image);
+    }
+
+    /**
      * @return the CollectableSet of the decoratedType
      */
     public CollectableSet getCollectableSet() {

--- a/backend/src/main/java/tech/geocodeapp/geocode/collectable/decorator/ConcreteCollectableType.java
+++ b/backend/src/main/java/tech/geocodeapp/geocode/collectable/decorator/ConcreteCollectableType.java
@@ -12,6 +12,7 @@ public class ConcreteCollectableType implements CollectableTypeComponent {
     private Rarity rarity;
     private UUID id;
     private CollectableSet set;
+    private String image;
 
     public ConcreteCollectableType() {
 
@@ -45,6 +46,16 @@ public class ConcreteCollectableType implements CollectableTypeComponent {
     @Override
     public void setId(UUID id) {
         this.id = id;
+    }
+
+    @Override
+    public String getImage() {
+        return image;
+    }
+
+    @Override
+    public void setImage(String image) {
+        this.image=image;
     }
 
     @Override

--- a/backend/src/main/java/tech/geocodeapp/geocode/collectable/factory/BasicCollectableTypeFactory.java
+++ b/backend/src/main/java/tech/geocodeapp/geocode/collectable/factory/BasicCollectableTypeFactory.java
@@ -9,7 +9,7 @@ public class BasicCollectableTypeFactory extends AbstractCollectableTypeFactory 
 
     /**
      * Creates the a new {@link ConcreteCollectableType} and sets its variables to the values obtained from parsing properties
-     * @param property A String containing the values of name, rarity and id in that order separated by a #
+     * @param property A String containing the values of name, rarity, id and image in that order separated by a #
      * @param collectableTypeComponent Null as it is created here and decorated by the other factories if required
      * @return the created {@link ConcreteCollectableType} returned as a {@link CollectableTypeComponent} interface object
      */
@@ -21,11 +21,13 @@ public class BasicCollectableTypeFactory extends AbstractCollectableTypeFactory 
         String name = split[0];
         Rarity rarity = Rarity.valueOf(split[1]);
         UUID id = UUID.fromString(split[2]);
+        String image = split[3];
 
         CollectableTypeComponent toReturn = new ConcreteCollectableType();
         toReturn.setName(name);
         toReturn.setRarity(rarity);
         toReturn.setId(id);
+        toReturn.setImage(image);
 
         return toReturn;
    }

--- a/backend/src/main/java/tech/geocodeapp/geocode/collectable/manager/CollectableTypeManager.java
+++ b/backend/src/main/java/tech/geocodeapp/geocode/collectable/manager/CollectableTypeManager.java
@@ -18,13 +18,15 @@ public class CollectableTypeManager {
         CollectableTypeContext context = new CollectableTypeContext(new BasicCollectableTypeStrategy());
         AbstractCollectableTypeFactory factory = context.executeStrategy();
 
-        //create a String to store name, rarity and id in that order separated by a #
+        //create a String to store name, rarity, id and image in that order separated by a #
         String property;
         property = type.getName();
         property += "#";
         property += type.getRarity().toString();
         property += "#";
         property += type.getId().toString();
+        property += "#";
+        property += type.getImage();
 
         //use property String to build a ConcreteCollectableType using the BasicCollectableTypeFactory
         builtType = factory.decorateCollectableType(property, null);


### PR DESCRIPTION
Added missing image variable to the ConcreteCollectableType and required methods for setting and getting it to CollectableTypeComponent and all classes implementing it. The CollectableTypeManager and BasicCollectableTypeFactory have been updated to correctly set the image to the same one as the CollectableType the CollectableTypeComponent is being built from.