### PR TITLE
Add UNIQUE rarity type to the Rarity enum

### DIFF
--- a/backend/src/main/java/tech/geocodeapp/geocode/collectable/model/Rarity.java
+++ b/backend/src/main/java/tech/geocodeapp/geocode/collectable/model/Rarity.java
@@ -9,10 +9,11 @@ import com.fasterxml.jackson.annotation.JsonCreator;
  */
 public enum Rarity {
   COMMON("COMMON"),
-    UNCOMMON("UNCOMMON"),
-    RARE("RARE"),
-    EPIC("EPIC"),
-    LEGENDARY("LEGENDARY");
+  UNCOMMON("UNCOMMON"),
+  RARE("RARE"),
+  EPIC("EPIC"),
+  LEGENDARY("LEGENDARY"),
+  UNIQUE("UNIQUE");
 
   private String value;
 


### PR DESCRIPTION
Create a unique rarity to exclude a type from being created by GeoCodes.