### PR TITLE
Various optimisations and improvements on the Explore page

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -7,9 +7,6 @@ const routes: Routes = [
     loadChildren: () => import('./tabs/tabs.module').then(m => m.TabsPageModule)
   },
   {
-    path: 'geocode-create',
-    loadChildren: () => import('./tabs/geocode/geocode-create/geocode-create.module').then(m => m.GeocodeCreatePageModule)
-  },  {
     path: 'welcome',
     loadChildren: () => import('./welcome/welcome.module').then( m => m.WelcomePageModule)
   }

--- a/frontend/src/app/tabs/collectable/collectable.page.html
+++ b/frontend/src/app/tabs/collectable/collectable.page.html
@@ -1,18 +1,17 @@
 <ion-header>
   <ion-toolbar>
-    <ion-title>Collectables</ion-title>
-    <ng-template [ngIf]="isAdmin()">
-      <ion-buttons slot="end">
-        <ion-button (click)="addSet()">
-          <ion-icon name="add-outline"></ion-icon>
-          <ion-label>New Set</ion-label>
-        </ion-button>
-      </ion-buttons>
-    </ng-template>
+    <ion-title>Collections</ion-title>
   </ion-toolbar>
 </ion-header>
 
 <ion-content>
+  <ng-template [ngIf]="isAdmin()">
+    <ion-fab vertical="bottom" horizontal="end" slot="fixed">
+      <ion-fab-button (click)="addSet()">
+        <ion-icon name="add"></ion-icon>
+      </ion-fab-button>
+    </ion-fab>
+  </ng-template>
   <ion-card *ngFor="let set of sets">
     <ion-card-content>
       <div class="header">

--- a/frontend/src/app/tabs/geocode/geocode-contents/geocode-contents.page.html
+++ b/frontend/src/app/tabs/geocode/geocode-contents/geocode-contents.page.html
@@ -1,6 +1,9 @@
 <ion-header>
   <ion-toolbar>
-    <ion-title>Find GeoCode</ion-title>
+    <ion-title>Open GeoCode</ion-title>
+    <ion-buttons slot="start">
+      <ion-back-button defaultHref="explore"></ion-back-button>
+    </ion-buttons>
     <ion-buttons slot="end">
       <ion-button (click)="scan()">
         <ion-icon name="qr-code-outline"></ion-icon>

--- a/frontend/src/app/tabs/geocode/geocode-create/geocode-create.page.html
+++ b/frontend/src/app/tabs/geocode/geocode-create/geocode-create.page.html
@@ -1,5 +1,8 @@
 <ion-header>
   <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-back-button defaultHref="explore"></ion-back-button>
+    </ion-buttons>
     <ion-title>Create GeoCode</ion-title>
   </ion-toolbar>
 </ion-header>

--- a/frontend/src/app/tabs/geocode/geocode-create/geocode-create.page.ts
+++ b/frontend/src/app/tabs/geocode/geocode-create/geocode-create.page.ts
@@ -77,7 +77,7 @@ request: CreateGeoCodeRequest= {
         this.hints=[];
         this.locations=[];
         this.difficulty=[];
-        this.navCtrl.navigateBack('/geocode');
+        this.navCtrl.navigateBack('/explore').then().catch();
       });
 
   }

--- a/frontend/src/app/tabs/geocode/geocode-routing.module.ts
+++ b/frontend/src/app/tabs/geocode/geocode-routing.module.ts
@@ -8,11 +8,11 @@ const routes: Routes = [
     component: GeocodePage
   },
   {
-    path: 'geocode-contents',
+    path: 'open/:id',
     loadChildren: () => import('./geocode-contents/geocode-contents.module').then(m => m.GeocodeContentsPageModule)
   },
   {
-    path: 'geocode-create',
+    path: 'create-geocode',
     loadChildren: () => import('./geocode-create/geocode-create.module').then(m => m.GeocodeCreatePageModule)
   }
 ];

--- a/frontend/src/app/tabs/geocode/geocode.page.html
+++ b/frontend/src/app/tabs/geocode/geocode.page.html
@@ -63,7 +63,6 @@
 
   <ion-fab vertical="bottom" horizontal="end" slot="fixed">
     <ion-fab-button color="button" [routerLink]="['create-geocode']">
-      Create GeoCode
       <ion-icon  name="add-outline"></ion-icon>
     </ion-fab-button>
   </ion-fab>

--- a/frontend/src/app/tabs/geocode/geocode.page.html
+++ b/frontend/src/app/tabs/geocode/geocode.page.html
@@ -1,6 +1,6 @@
 <ion-header>
   <ion-toolbar >
-    <ion-title id="page-title">Geocode</ion-title>
+    <ion-title id="page-title">Explore</ion-title>
   </ion-toolbar>
 </ion-header>
 
@@ -55,6 +55,7 @@
             <ion-col>{{geocode.longitude}} </ion-col>
           </ion-row>
           <ion-button id="button" color="button" (click)="findGeoCode(geocode)"  >Open GeoCode</ion-button>
+          <ion-button (click)="openInMaps(geocode)">Open Location in Google Maps</ion-button>
 
       </ion-card-content>
     </ion-card>

--- a/frontend/src/app/tabs/geocode/geocode.page.html
+++ b/frontend/src/app/tabs/geocode/geocode.page.html
@@ -54,15 +54,16 @@
             <ion-col>Longitude</ion-col>
             <ion-col>{{geocode.longitude}} </ion-col>
           </ion-row>
-          <ion-button id="button" color="button" (click)="findGeoCode(geocode)"  >Find GeoCode</ion-button>
+          <ion-button id="button" color="button" (click)="findGeoCode(geocode)"  >Open GeoCode</ion-button>
 
       </ion-card-content>
     </ion-card>
 </div>
 
   <ion-fab vertical="bottom" horizontal="end" slot="fixed">
-    <ion-fab-button color="button">
-      <ion-icon  name="add-outline"(click)="createGeoCode()"></ion-icon>
+    <ion-fab-button color="button" [routerLink]="['create-geocode']">
+      Create GeoCode
+      <ion-icon  name="add-outline"></ion-icon>
     </ion-fab-button>
   </ion-fab>
 

--- a/frontend/src/app/tabs/geocode/geocode.page.ts
+++ b/frontend/src/app/tabs/geocode/geocode.page.ts
@@ -7,7 +7,7 @@ import {
   GetGeoCodesResponse,
   UpdateAvailabilityRequest,
   UpdateAvailabilityResponse,
-  GetGeoCodesByDifficultyRequest
+  GetGeoCodesByDifficultyRequest, GeoCode
 } from '../../services/geocode-api';
 import {GoogleMapsLoader} from '../../services/GoogleMapsLoader';
 
@@ -24,9 +24,9 @@ export class GeocodePage implements AfterViewInit  {
   map;
   mapMarker;
   markers= [];
-  geocodes = [];
+  geocodes: GeoCode[] = [];
   selected=[];
-  isHidden=false;
+  isHidden=true;
   height='60%';
 
 
@@ -36,8 +36,9 @@ export class GeocodePage implements AfterViewInit  {
     private geocodeApi: GeoCodeService,
     private mapsLoader: GoogleMapsLoader
   ) {
-    this.geocodes = [{id:'123456789',latitude:-25.75625115327836,longitude:28.235629260918344,difficulty:'EASY',description:'TEST'}];
+    this.geocodes = [];
     this.selected= this.geocodes;
+    this.close();
   }
 
   //Create map and add mapmarkers of geocodes
@@ -68,18 +69,8 @@ export class GeocodePage implements AfterViewInit  {
   }
 
   //Navigate to findGeoCode page
-  findGeoCode(geocode){
-    const navigationExtras: NavigationExtras = {
-      queryParams: {
-        geocode
-      }
-    };
-   this.navCtrl.navigateForward('/geocode/geocode-contents',navigationExtras);
-  }
-
-  //navigate to the create geocode page
-  createGeoCode(){
-    this.navCtrl.navigateForward('/geocode/geocode-create');
+  async findGeoCode(geocode){
+    await this.navCtrl.navigateForward('/explore/open/'+geocode.id,{ state: {geocode} });
   }
 
   //Call Geocode service and update Availability

--- a/frontend/src/app/tabs/geocode/geocode.page.ts
+++ b/frontend/src/app/tabs/geocode/geocode.page.ts
@@ -52,11 +52,10 @@ export class GeocodePage implements AfterViewInit  {
 
   }
 
-  ngAfterViewInit(): void {
-    this.mapsLoader.load().then(handle => {
-      this.googleMaps = handle;
-      this.loadMap();
-    }).catch();
+  async ngAfterViewInit() {
+    this.googleMaps = await this.mapsLoader.load();
+    this.loadMap();
+    this.getAllMap();
   }
 
 

--- a/frontend/src/app/tabs/geocode/geocode.page.ts
+++ b/frontend/src/app/tabs/geocode/geocode.page.ts
@@ -199,4 +199,8 @@ export class GeocodePage implements AfterViewInit  {
     this.height='90%';
   }
 
+  openInMaps(geocode: GeoCode) {
+    window.open('https://www.google.com/maps/search/?api=1&query='+geocode.latitude+'%2C'+geocode.longitude);
+  }
+
 }

--- a/frontend/src/app/tabs/tabs-routing.module.ts
+++ b/frontend/src/app/tabs/tabs-routing.module.ts
@@ -12,7 +12,7 @@ const routes: Routes = [
         loadChildren: () => import('./geocode/geocode.module').then(m => m.GeocodePageModule)
       },
       {
-        path: 'collectables',
+        path: 'collections',
         loadChildren: () => import('./collectable/collectable.module').then(m => m.CollectablePageModule)
       },
       {

--- a/frontend/src/app/tabs/tabs-routing.module.ts
+++ b/frontend/src/app/tabs/tabs-routing.module.ts
@@ -8,7 +8,7 @@ const routes: Routes = [
     component: TabsPage,
     children: [
       {
-        path: 'geocode',
+        path: 'explore',
         loadChildren: () => import('./geocode/geocode.module').then(m => m.GeocodePageModule)
       },
       {
@@ -25,7 +25,7 @@ const routes: Routes = [
       },
       {
         path: '',
-        redirectTo: '/geocode',
+        redirectTo: '/explore',
         pathMatch: 'full'
       }
     ]

--- a/frontend/src/app/tabs/tabs.page.html
+++ b/frontend/src/app/tabs/tabs.page.html
@@ -6,7 +6,7 @@
       <ion-label>Explore</ion-label>
     </ion-tab-button>
 
-    <ion-tab-button tab="collectables">
+    <ion-tab-button tab="collections">
       <ion-icon [src]="collectableIcon"></ion-icon>
       <ion-label>Collections</ion-label>
     </ion-tab-button>

--- a/frontend/src/app/tabs/tabs.page.html
+++ b/frontend/src/app/tabs/tabs.page.html
@@ -1,7 +1,7 @@
 <ion-tabs [slot]="tabsPlacement" >
 
   <ion-tab-bar slot="bottom">
-    <ion-tab-button tab="geocode">
+    <ion-tab-button tab="explore">
       <ion-icon  [src]="geoCodeIcon"></ion-icon>
       <ion-label>Explore</ion-label>
     </ion-tab-button>

--- a/frontend/src/app/welcome/welcome.page.ts
+++ b/frontend/src/app/welcome/welcome.page.ts
@@ -15,13 +15,13 @@ export class WelcomePage {
     private router: Router
   ) {
     if (this.keycloak.getKeycloakInstance().authenticated) {
-      this.router.navigate(['geocode']).then().catch();
+      this.router.navigate(['explore']).then().catch();
     }
   }
 
   async login() {
     await this.keycloak.login({
-      redirectUri: environment.baseRedirectURI+'/geocode'
+      redirectUri: environment.baseRedirectURI+'/explore'
     });
   }
 


### PR DESCRIPTION
- Renamed GeoCode tab to Explore in user-facing UI
- Support opening contents of arbitrary geocodes without needing to go through the Explore page (for deep linking and user sharing). Requires some backend+Swagger changes to actually implement.
- Various label changes
- Support opening geocode locations in Google Maps